### PR TITLE
Rebuild main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build
+on:
+  push:
+    branches: main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{secrets.BOT_TOKEN}}
+      - uses: crazy-max/ghaction-import-gpg@v3.0.2
+        with:
+          gpg-private-key: ${{secrets.BOT_GPG_SIGN_KEY}}
+          git-user-signingkey: true
+      - run: npm ci
+      - run: git diff --quiet || git commit --all -m 'Build' --gpg-sign=FD5E66973D2B8B86
+      - run: git push --signed=if-asked

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -19,5 +19,5 @@ jobs:
         uses: ./node-version # this would be nodenv/actions/node-version@v2 for most users
       - uses: actions/setup-node@v1
         with:
-          node-version: '${{ steps.nodenv.outputs.node-version }}'
+          node-version: "${{ steps.nodenv.outputs.node-version }}"
       - run: node -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 
 name: Release
 on:
-  push: { tags: 'v[0-9]+.[0-9]+.[0-9]+' }
+  push: { tags: "v[0-9]+.[0-9]+.[0-9]+" }
 
 jobs:
   github:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,7 +2,7 @@ name: Sync Subtrees
 on:
   push:
     branches: main
-    tags: 'v[0-9]+.[0-9]+.[0-9]+'
+    tags: "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test
-on: [ push, pull_request ]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Workflow runs on pushes to `main` branch and auto-commits back any changes to the dist files after a clean build.

This way any changes made via merge on github will be _effective_ on main without needing a versioned (tagged) release.

closes #16 