### PR TITLE
set output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,5 +20,5 @@ jobs:
           gpg_private_key: ${{secrets.BOT_GPG_SIGN_KEY}}
           git_user_signingkey: true
       - run: npm ci
-      - run: git diff --quiet || git commit -am Build -S FD5E66973D2B8B86
+      - run: git diff --quiet || git commit -am Build --gpg-sign=FD5E66973D2B8B86
       - run: git push --signed=if-asked

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.10",
+        "@actions/core": "^1.10.1",
         "@actions/tool-cache": "^2"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
   "bugs": {
     "url": "https://github.com/nodenv/actions/issues"
   },
-  "actions": "node-version setup-nodenv",
+  "config": {
+    "actions": "node-version setup-nodenv"
+  },
   "scripts": {
     "clean": "git checkout -- */dist",
     "lint": "standard --fix",
     "posttest": "npm run lint",
-    "test": "jest $npm_package_actions",
-    "prepare": "for a in $npm_package_actions; do (cd $a && echo $PWD && ncc build); done",
+    "test": "jest $npm_package_config_actions",
+    "prepare": "for a in $npm_package_config_actions; do (cd $a && echo $PWD && ncc build); done",
     "preversion": "npm run prepare",
     "version": "git add -- */dist",
     "postversion": "git push --follow-tags"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "postversion": "git push --follow-tags"
   },
   "dependencies": {
-    "@actions/core": "^1.10",
+    "@actions/core": "^1.10.1",
     "@actions/tool-cache": "^2"
   },
   "devDependencies": {


### PR DESCRIPTION
- **bump to latest actions/core**
- **npm broke package env vars**
- **fix git-commit command**

This should hopefully resolve #63 


For anyone watching at home, npm broke their package-json-flattening-as-env behavior. So `npm_package_actions` was no longer a valid env var. And instead of failing on the reference, it just quietly replaced with empty string. So npm breaks a long-standing feature. And their shell setup still doesn't use `-u` to help guard unset env vars.

So with the `prepare` script no longer actually, ya know, PREPARING ANYTHING, the `npm ci` step was now essentially a noop. Which meant the build.yml workflow was quietly broken as well.

thanks npm.